### PR TITLE
fatbin: make the format more robust

### DIFF
--- a/cmd/gofat/gofat.go
+++ b/cmd/gofat/gofat.go
@@ -99,7 +99,9 @@ func build(args []string) {
 
 	f, err := os.OpenFile(*out, os.O_WRONLY|os.O_APPEND, 0777)
 	must(err)
-	fat := fatbin.NewWriter(f)
+	info, err := f.Stat()
+	must(err)
+	fat := fatbin.NewWriter(f, info.Size(), runtime.GOOS, runtime.GOARCH)
 
 	for _, goarch := range strings.Split(*goarches, ",") {
 		for _, goos := range strings.Split(*gooses, ",") {

--- a/fatbin/fatbin_test.go
+++ b/fatbin/fatbin_test.go
@@ -72,7 +72,7 @@ func TestSniff(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	goos, goarch, size, err := Sniff(f)
+	goos, goarch, size, err := Sniff(f, info.Size())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestSniff(t *testing.T) {
 
 func TestLinuxElf(t *testing.T) {
 	r := bytes.NewReader(svelteLinuxElfBinary)
-	goos, goarch, size, err := Sniff(r)
+	goos, goarch, size, err := Sniff(r, int64(r.Len()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/fatbin/footer.go
+++ b/fatbin/footer.go
@@ -1,0 +1,51 @@
+// Copyright 2019 GRAIL, Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package fatbin
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+
+	"github.com/cespare/xxhash"
+)
+
+const (
+	magic    uint32 = 0x5758ba2c
+	headersz        = 20
+)
+
+var (
+	errNoFooter = errors.New("binary contains no footer")
+
+	bin = binary.LittleEndian
+)
+
+func writeFooter(w io.Writer, offset int64) (int, error) {
+	var p [headersz]byte
+	bin.PutUint64(p[:8], uint64(offset))
+	bin.PutUint32(p[8:12], magic)
+	bin.PutUint64(p[12:20], xxhash.Sum64(p[:12]))
+	return w.Write(p[:])
+}
+
+func readFooter(r io.ReaderAt, size int64) (offset int64, err error) {
+	if size < headersz {
+		return 0, errNoFooter
+	}
+	var p [headersz]byte
+	_, err = r.ReadAt(p[:], size-headersz)
+	if err != nil {
+		return 0, err
+	}
+	if bin.Uint32(p[8:12]) != magic {
+		return 0, errNoFooter
+	}
+	offset = int64(bin.Uint64(p[:8]))
+	if xxhash.Sum64(p[:12]) != bin.Uint64(p[12:20]) {
+		return 0, ErrCorruptedImage
+	}
+	return
+}

--- a/fatbin/footer_test.go
+++ b/fatbin/footer_test.go
@@ -1,0 +1,79 @@
+// Copyright 2019 GRAIL, Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package fatbin
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestReadWriteFooter(t *testing.T) {
+	for _, sz := range []int64{0, 12, 1e12, 1e13 + 4} {
+		var b bytes.Buffer
+		if _, err := writeFooter(&b, sz); err != nil {
+			t.Error(err)
+			continue
+		}
+		off, err := readFooter(bytes.NewReader(b.Bytes()), int64(b.Len()))
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if got, want := off, sz; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+
+		padded := paddedReaderAt{bytes.NewReader(b.Bytes()), int64(sz) * 100}
+		off, err = readFooter(padded, int64(sz)*100+int64(b.Len()))
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if got, want := off, sz; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestCorruptedFooter(t *testing.T) {
+	var b bytes.Buffer
+	if _, err := writeFooter(&b, 1234); err != nil {
+		t.Fatal(err)
+	}
+	n := b.Len()
+	for i := 0; i < n; i++ {
+		if i >= n-12 && i < n-8 {
+			continue //skip magic
+		}
+		p := make([]byte, b.Len())
+		copy(p, b.Bytes())
+		p[i]++
+		_, err := readFooter(bytes.NewReader(p), int64(len(p)))
+		if got, want := err, ErrCorruptedImage; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	}
+}
+
+type paddedReaderAt struct {
+	io.ReaderAt
+	N int64
+}
+
+func (r paddedReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
+	off -= r.N
+	for i := range p {
+		p[i] = 0
+	}
+	switch {
+	case off < -int64(len(p)):
+		return len(p), nil
+	case off < 0:
+		p = p[-off:]
+		off = 0
+	}
+	return r.ReaderAt.ReadAt(p, off)
+}


### PR DESCRIPTION
Fatbin currently relies on the sniffers to be able to determine the
offset of the fatbin zip. This is done by inspecting the image format
directly. This approach has not proven to be robust. While it seems
to work on common configurations inside of GRAIL, we have reports
(e.g., issue #8) of the approach failing in other configurations.

This change changes the format to include a magic value to identify
fatbin binaries, and a footer that stores the fatbin offset directly.
This should prove a much more robust approach as we do not rely on
accurately reading the underlying image format with all of of its
implementation-specific variations.