### PR TITLE
Fix crashes in s3file.go

### DIFF
--- a/file/s3file/s3file.go
+++ b/file/s3file/s3file.go
@@ -723,9 +723,9 @@ func (f *s3File) Stat(ctx context.Context) (file.Info, error) {
 func newInfo(path string, output *s3.GetObjectOutput) *s3Info {
 	return &s3Info{
 		name:    filepath.Base(path),
-		size:    *output.ContentLength,
-		modTime: *output.LastModified,
-		etag:    *output.ETag,
+		size:    aws.Int64Value(output.ContentLength),
+		modTime: aws.TimeValue(output.LastModified),
+		etag:    aws.StringValue(output.ETag),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20191007204434-a023cd5227bd // indirect
 	google.golang.org/grpc v1.24.0 // indirect
-	v.io v0.0.0-20200306001120-b448c780c269
+	v.io v0.1.7
 	v.io/x/lib v0.1.4
 )
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20191007204434-a023cd5227bd // indirect
 	google.golang.org/grpc v1.24.0 // indirect
-	v.io v0.1.7
+	v.io v0.0.0-20200306001120-b448c780c269
 	v.io/x/lib v0.1.4
 )
 


### PR DESCRIPTION
Fixes crashes like the following.  I don't know exactly what conditions cause the AWS response to have nil values, but this fixes trivial nil pointer dereferences and seems better regardless.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc55174]

goroutine 579033 [running]:
github.com/grailbio/base/file/s3file.newInfo(...)
/Users/toddwang/go/pkg/mod/github.com/grailbio/base@v0.0.7/file/s3file/s3file.go:726
github.com/grailbio/base/file/s3file.(*s3File).handleStat(0xc03ba87360, 0x2bd4760, 0xc03bd4d350, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc03be145a0)
/Users/toddwang/go/pkg/mod/github.com/grailbio/base@v0.0.7/file/s3file/s3file.go:761 +0x424
github.com/grailbio/base/file/s3file.(*s3File).handleRequests(0xc03ba87360)
/Users/toddwang/go/pkg/mod/github.com/grailbio/base@v0.0.7/file/s3file/s3file.go:657 +0x1a7
created by github.com/grailbio/base/file/s3file.(*s3Impl).internalOpen
/Users/toddwang/go/pkg/mod/github.com/grailbio/base@v0.0.7/file/s3file/s3file.go:457 +0x1f2
```