### PR TITLE
Remove `newInfo` because it is dead code

### DIFF
--- a/file/s3file/s3file.go
+++ b/file/s3file/s3file.go
@@ -694,15 +694,6 @@ func (f *s3File) Stat(ctx context.Context) (file.Info, error) {
 	return f.info, nil
 }
 
-func newInfo(path string, output *s3.GetObjectOutput) *s3Info {
-	return &s3Info{
-		name:    filepath.Base(path),
-		size:    *output.ContentLength,
-		modTime: *output.LastModified,
-		etag:    *output.ETag,
-	}
-}
-
 func (f *s3File) handleStat(req request) {
 	ctx := req.ctx
 	clients, err := f.provider.Get(ctx, "GetObject", f.name)
@@ -826,9 +817,6 @@ func (f *s3File) startGetObjectRequest(ctx context.Context, policy *retryPolicy)
 		}
 		f.bodyReader = output.Body // take ownership
 		f.bodyReaderRequestIDs = ids
-		if f.info == nil {
-			f.info = newInfo(f.name, output)
-		}
 		return nil
 	}
 }


### PR DESCRIPTION
1. `startGetObjectRequest` will only call `newInfo` if `f.info == nil`.
2. `startGetObjectRequest` is only called by `handleRead`.
3. `handleRead` is only called to handle a `readRequest`.
4. `readRequest` is only issued in `(*s3Reader).Read`.
5. The only way to get an `*s3Reader` is by `(*s3File).Reader`. It only does this if `f.mode == readonly`.
6. The only way to get a `readonly` `*s3File` is by `(*s3Impl).Open`.
7. `(*s3Impl).Open` will only return successfully if the `handleStat` sends a non-error `response`, via `runRequest` and `statRequest`.
8. `handleStat` only sends a non-error response after populating `f.info` with the result of `stat`, when `stat` returns a `nil` error. `stat` only returns a `nil` error when the `*s3Info` it returns is non-nil.
9. Therefore, `f.info != nil` in `startGetObjectRequest`, and it will not call `newInfo`.

I think the `f.info == nil` case became obsolete in 3cf2bd3a402b890b1e04641627c2044fb9fe986e, which introduced the `statRequest` on `(*s3Impl).Open`.

This was raised and originally reasoned about in https://github.com/grailbio/base/pull/16: https://github.com/grailbio/base/pull/16#issuecomment-622092442.