### PR TITLE
Remove Go 1.12 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.12.x
   - 1.13.x
 os:
   - linux


### PR DESCRIPTION
As of https://github.com/grailbio/base/commit/349e2927c13d83dc69e24c7e2e651d1e02840a89, we are no longer Go 1.12-compatible. Go 1.12 is 3 versions out of date now, so we are fully dropping support.