### PR TITLE
Build on xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 os:
   - linux
   - osx
-dist: trusty
+dist: xenial
 sudo: false
 install: true
 script:

--- a/security/ssh/certificateauthority/ssh_test.go
+++ b/security/ssh/certificateauthority/ssh_test.go
@@ -64,21 +64,11 @@ func TestAuthority(t *testing.T) {
 	cmd := exec.Command("ssh-keygen", "-L", "-f", "-")
 	cmd.Stdin = bytes.NewBuffer([]byte(preCreatedUserCert))
 	preCreatedOutput, err := cmd.Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			t.Logf("stderr of %v: %s", cmd, string(exitErr.Stderr))
-		}
-	}
 	assert.NoError(t, err)
 
 	cmd = exec.Command("ssh-keygen", "-L", "-f", "-")
 	cmd.Stdin = bytes.NewBuffer([]byte(sshCert))
 	output, err := cmd.Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			t.Logf("stderr of %v: %s", cmd, string(exitErr.Stderr))
-		}
-	}
 	assert.NoError(t, err)
 
 	if string(preCreatedOutput) != string(output) {

--- a/security/ssh/certificateauthority/ssh_test.go
+++ b/security/ssh/certificateauthority/ssh_test.go
@@ -64,11 +64,21 @@ func TestAuthority(t *testing.T) {
 	cmd := exec.Command("ssh-keygen", "-L", "-f", "-")
 	cmd.Stdin = bytes.NewBuffer([]byte(preCreatedUserCert))
 	preCreatedOutput, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Logf("stderr of %v: %s", cmd, string(exitErr.Stderr))
+		}
+	}
 	assert.NoError(t, err)
 
 	cmd = exec.Command("ssh-keygen", "-L", "-f", "-")
 	cmd.Stdin = bytes.NewBuffer([]byte(sshCert))
 	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Logf("stderr of %v: %s", cmd, string(exitErr.Stderr))
+		}
+	}
 	assert.NoError(t, err)
 
 	if string(preCreatedOutput) != string(output) {


### PR DESCRIPTION
When we synced https://github.com/grailbio/base/commit/4ef097c9ae4215a15549a15ea28661a147cfa0ef#diff-8b7b38c62b815a44970c5332bcadd718R64-R72 from our internal repository, we introduced a dependence on `ssh-keygen` support of the `-` argument to read from standard input. The version of `ssh-keygen` shipped on trusty does not support it. Upgrade our build to use xenial. (We may consider upgrading further, but I am trying to make the minimal changes to make our CI build succeed again).