### PR TITLE
Make S3 UploadPartSize a file.Opt

### DIFF
--- a/file/s3file/s3file_test.go
+++ b/file/s3file/s3file_test.go
@@ -403,15 +403,9 @@ func testOverwriteWhileReading(t *testing.T, impl file.Implementation, pathPrefi
 
 func TestWriteLargeFile(t *testing.T) {
 	// Reduce the upload chunk size to issue concurrent upload requests to S3.
-	oldUploadPartSize := s3file.UploadPartSize
-	s3file.UploadPartSize = 128
-	defer func() {
-		s3file.UploadPartSize = oldUploadPartSize
-	}()
-
 	ctx := context.Background()
 	provider := &testProvider{clients: []s3iface.S3API{s3test.NewClient(t, "b")}}
-	impl := s3file.NewImplementation(provider, s3file.Options{})
+	impl := s3file.NewImplementation(provider, s3file.Options{UploadPartSize: 128})
 	path := "s3://b/test.txt"
 	f, err := impl.Create(ctx, path)
 	assert.NoError(t, err)


### PR DESCRIPTION
A process using file.Create("s3://...") with ~100KB files has been seen to have low throughput. In profiles, it appears that there is significant time spent in GC with the sync.Pool created in newUploader accounting for 90+% of heap usage.

I looked at a few ideas to avoid this:
1. Make it possible to reuse sync.Pool across file creations.
2. Make it possible to change the chunk size the pool uses.
3. Start with a small buffer initially and if writes grow past it then copy to the sync.Pool. If the writer closes before the data grows past the small buffer, upload the small buffer contents.

I went with approach #2 in this PR because it seemed simplest.